### PR TITLE
Close DNS resolver's sockets properly on Windows

### DIFF
--- a/src/util/rsdnsutils.cc
+++ b/src/util/rsdnsutils.cc
@@ -265,7 +265,11 @@ bool rsGetRecordByNameSpecDNS(const std::string& servername, unsigned short serv
 	if( send_size < 0)
 	{
 		RS_ERR("Send Failed with size = ", send_size);
+		#ifndef WINDOWS_SYS
 		close(s);
+		#else
+		closesocket(s);
+		#endif
 		return false;
 	}
 
@@ -282,7 +286,11 @@ bool rsGetRecordByNameSpecDNS(const std::string& servername, unsigned short serv
 	                         , (struct sockaddr*)&serverAddr
 	                         , &sa_size
 	                         );
+	#ifndef WINDOWS_SYS
 	close(s); // No more need of this socket, close it.
+	#else
+	closesocket(s);
+	#endif
 	if(rec_size <= 0)
 	{
 		RS_ERR("Receive Failed");


### PR DESCRIPTION
Use closesocket() instead of close() under Windows as the later doesn't close them at all, which results in 72 sockets being allocated per hour.