### PR TITLE
Limit JSON API's getFileData chunk size

### DIFF
--- a/src/jsonapi/jsonapi.cpp
+++ b/src/jsonapi/jsonapi.cpp
@@ -333,7 +333,7 @@ JsonApiServer::JsonApiServer(): configMutex("JsonApiServer config"),
 				RS_SERIAL_PROCESS(requested_size);
 			}
 
-			if(requested_size > 10485760)
+			if(requested_size > 1048576)
 				errorMessage = "requested_size is too big! Better less then 1M";
 			else
 			{


### PR DESCRIPTION
Restrict JSON API's getFileData to 1 MB instead of 10 MB, as that is the proper chunk size.